### PR TITLE
GitHub actions auto project

### DIFF
--- a/.github/workflows/autoAssignProject.yml
+++ b/.github/workflows/autoAssignProject.yml
@@ -10,9 +10,11 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GITHUB_PROJECT_URL: https://github.com/fabianvanhummel/basements-and-lizards/projects/1
+        GITHUB_PROJECT_COLUMN_NAME: Needs triage
     - name: add-new-prs-to-repository-based-project-column
       uses: docker://takanabe/github-actions-automate-projects:v0.0.1
       if: github.event_name == 'pull_request' && github.event.action == 'opened'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GITHUB_PROJECT_URL: https://github.com/fabianvanhummel/basements-and-lizards/projects/1
+        GITHUB_PROJECT_COLUMN_NAME: Needs triage


### PR DESCRIPTION
Heb een beetje rondgespeurd, en dit als voorbeeld gepakt: [Automate projects](https://github.com/marketplace/actions/automate-projects).

Het lukt mij niet echt om zo'n workflow te testen terwijl hij niet in de default branch zit. Volgens mij zou het wel moeten kunnen met wat command line shit ([ref](https://stackoverflow.com/questions/63362126/github-actions-how-to-run-a-workflow-created-on-a-non-master-branch-from-the-wo)). Maar het liefste pull ik hem denk ik gewoon in Develop en probeer het dan even. Als het niet werkt gooi ik het weer uit Develop en ga ik wat verder onderzoek doen.
Als een van jullie zich MLG voelt om dit te testen vanuit een andere branch vind ik dat ook helemaal prima ofc!

Closes #7 