### PR TITLE
Pim: Events vanuit paths & Event tracking

### DIFF
--- a/src/books/maze.json
+++ b/src/books/maze.json
@@ -147,12 +147,24 @@
         {
           "to": "portal-chamber",
           "name": "Red Portal",
-          "events": ["portal-puzzel-step-1", "portal-puzzel-step-4", "portal-puzzel-step-5"]
+          "events": [
+            "portal-puzzel-step-1",
+            "portal-puzzel-step-2-fail",
+            "portal-puzzel-step-3-fail",
+            "portal-puzzel-step-4",
+            "portal-puzzel-step-5"
+          ]
         },
         {
           "to": "portal-chamber",
           "name": "Green Portal",
-          "events": ["portal-puzzel-step-2", "portal-puzzel-step-3"]
+          "events": [
+            "portal-puzzel-step-1-fail",
+            "portal-puzzel-step-2",
+            "portal-puzzel-step-3",
+            "portal-puzzel-step-4-fail",
+            "portal-puzzel-step-5-fail"
+          ]
         }
       ]
     }
@@ -161,21 +173,61 @@
     "portal-puzzel-step-1": {
       "message": "You are send back to the middle of the room, but the yellow portal station, something starts to glow."
     },
+    "portal-puzzel-step-1-fail": {
+      "blockedByEvents": ["portal-puzzel-step-1"],
+      "revertEvents": ["portal-puzzel-step-1-fail"],
+      "message": "Nothing interesting happened."
+    },
     "portal-puzzel-step-2": {
       "requirements": ["portal-puzzel-step-1"],
       "message": "Send back again, but the glow starts to increase in size and brightness."
+    },
+    "portal-puzzel-step-2-fail": {
+      "blockedByEvents": ["portal-puzzel-step-2"],
+      "revertEvents": ["portal-puzzel-step-1", "portal-puzzel-step-2-fail"],
+      "message": "The glow that was there a second ago disappeared again."
     },
     "portal-puzzel-step-3": {
       "requirements": ["portal-puzzel-step-2"],
       "message": "The glow grows again, it starts to look like a portal, but too small."
     },
+    "portal-puzzel-step-3-fail": {
+      "blockedByEvents": ["portal-puzzel-step-3"],
+      "revertEvents": [
+        "portal-puzzel-step-1",
+        "portal-puzzel-step-2",
+        "portal-puzzel-step-3-fail"
+      ],
+      "message": "The glow that was growing has now disappeared."
+    },
     "portal-puzzel-step-4": {
       "requirements": ["portal-puzzel-step-3"],
       "message": "The portal size increases again, but isn't as large as the other portals yet."
     },
+    "portal-puzzel-step-4-fail": {
+      "blockedByEvents": ["portal-puzzel-step-4"],
+      "revertEvents": [
+        "portal-puzzel-step-1",
+        "portal-puzzel-step-2",
+        "portal-puzzel-step-3",
+        "portal-puzzel-step-4-fail"
+      ],
+      "message": "The small portal grows smaller and then disappears leaving some shiny particles that dim slowly until they're gone."
+    },
     "portal-puzzel-step-5": {
       "requirements": ["portal-puzzel-step-4"],
       "message": "The yellow portal now has a normal size, you can probably use it now."
+    },
+    "portal-puzzel-step-5-fail": {
+      "blockedByEvents": ["portal-puzzel-step-5"],
+      "revertEvents": [
+        "portal-puzzel-step-1",
+        "portal-puzzel-step-2",
+        "portal-puzzel-step-3",
+        "portal-puzzel-step-4",
+        "portal-puzzel-step-5-fail"
+      ],
+      "message": "The portal starts to pulsate faster and faster until it explodes leaving an empty portal station once again."
     },
     "open-location-6": {
       "value": false,


### PR DESCRIPTION
Paar dingen:
- Ik heb een apart (draft) PR gemaakt zodat we kunnen kiezen of we het wel of niet gebruiken. EDIT: draft bestaat wss nie in gratis GitHub.
- Ik target de `path-events-and-event-tracking` branch. Als we dit PR eerst daarin mergen krijgen we automatisch de commits in die #53.
- Goed werk @JasperH93 met het voorbeeld want dat maakt de discussie wat concreter 👍 .
- Ik denk wel dat als we hier geen goede oplossing voor kunnen vinden, we het altijd kunnen FTB'en aangezien de app een hulpmiddel is en we dus niet persee alles tot in de details hoeven voor te kauwen. De hele puzzel kan namelijk ook gewoon worden uitgelegd in een description.

Hoe het werkt:
- De happy path is vrij standaard. Beide portals hebben events die een extra (geel) portaal laten groeien. Elke stap heeft als requirement de vorige stap.
- Als er fouten worden gemaakt is het wat lastiger, aangezien we dan dingen moeten resetten en het maakt de requirements wat ingewikkelder.
  - Resetten is denk ik vrij duidelijk, wanneer een event plaatsvind reset je de events uit `resetEvents` en deze kunnen daardoor nog steeds plaatsvinden.
  - `blockedByEvents` zorgt ervoor dat bepaalde events niet meer kunnen gebeuren als andere events zijn uitgevoerd. Het is eigenlijk een beetje een `NOT requirement`, dus we kunnen altijd bekijken of we het verwerken in de requirements. We moeten waarschijnlijk namelijk ook onderscheidt gaat maken tussen bijv.: `event has happened` en `item in intentory`.

Paar dingen die mijn methode versterken:
- Het maakt niet uit waar de portals staan mochten we ze in verschillende kamers zetten.
- We kunnen gemakkelijk een extra portal toevoegen en daar de `-fail` events aan toevoegen.
- Deze methode zou ook redelijk moeten werken als we hem gebruiken in combi met items/npcs.