### PR TITLE
Jap: Events vanuit paths & Event tracking 

### DIFF
--- a/src/books/maze.json
+++ b/src/books/maze.json
@@ -146,16 +146,70 @@
         },
         {
           "to": "portal-chamber",
-          "name": "Red Portal"
+          "name": "Red Portal",
+          "events": [
+            { 
+              "id": "portal-puzzle",
+              "value": "R"
+            }
+          ]
         },
         {
           "to": "portal-chamber",
-          "name": "Green Portal"
+          "name": "Green Portal",
+          "events": [
+            { 
+              "id": "portal-puzzle",
+              "value": "G"
+            }
+          ]
+        },
+        {
+          "to": "7",
+          "name": "Yellow Portal",
+          "requirements": [
+            "open-yellow-portal"
+          ]
         }
       ]
     }
   },
   "events": {
+    "portal-puzzle": {
+      "type": "stringBuilder",
+      "value": "",
+      "finalValue": "RGGRR",
+      "message": [
+        {
+          "success": "Step 1 succesfull",
+          "fail": "Step 1 failed"
+        },
+        {
+          "success": "Step 2 succesfull",
+          "fail": "Step 2 failed"
+        },
+        {
+          "success": "Step 3 succesfull",
+          "fail": "Step 3 failed"
+        },
+        {
+          "success": "Step 4 succesfull",
+          "fail": "Step 4 failed"
+        },
+        {
+          "success": "Step 5 succesfull",
+          "fail": "Step 5 failed"
+        }
+      ],
+      "events": [
+        "open-yellow-portal"
+      ]
+    },
+    "open-yellow-portal": {
+      "value": false,
+      "eventValue": true,
+      "message": "Yellow portal"
+    },
     "open-location-6": {
       "value": false,
       "eventValue": true,


### PR DESCRIPTION
Heb een alternatieve manier bedacht om de puzzel op te lossen, waarbij we een nieuw "type" event introduceren.
Beschrijving uit commit:
`
Dit is een nieuw event type waarbij er strings naar het event gestuurd kunnen worden. Deze probeert hij samen te voegen om op een resultaat te komen. Als het misgaat zal deze resetten, verder is een array met messages mogelijk, waarschijnlijk is een defaultvalue hiervoor ook handig. Zodra de doelwaarde bereikt is kunnen events getriggerd worden. Met dit event type kunnen we volgordelijke events makkelijk ondervangen.
`
Hopelijk is de uitleg in combinatie met de json een beetje duidelijk.

Mogelijk geldt hier een beetje het ding waar ik al eerder een afwijkende mening had, ik heb de neiging om de datastructuur een beetje schoon te houden en bouw dan graag wat extra logica, terwijl jullie dat misschien juist skeer vinden. #BISpecialist😄
Ik denk iig dat door events van verschillende types (later wss ook eentje met een teller) te introduceren we wat complexere situaties relatief eenvoudig kunnen opvangen in de json. Wat ons later ook weer helpt als we BM customization (binnen scope) en story builder (buiten scope) willen gaan maken.