### PR TITLE
A way to turn string into html code

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,12 +8,13 @@
     "@types/node": "^17.0.10",
     "@types/react": "^17.0.38",
     "@types/react-dom": "^17.0.11",
+    "html-react-parser": "^1.4.8",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-router-dom": "^6.0.2",
     "react-scripts": "4.0.3",
     "typescript": "^4.5.4",
-    "web-vitals": "^1.1.2" 
+    "web-vitals": "^1.1.2"
   },
   "scripts": {
     "start": "set port=1337 && craco start",

--- a/src/books/maze.json
+++ b/src/books/maze.json
@@ -6,7 +6,7 @@
   "locations": {
     "1": {
       "name": "Room number 1",
-      "description": "This is a default description of room number 1",
+      "description": "<div className='text-green-600'>This is a default description of room number 1</div>",
       "paths": [
         {
           "toLocationId": "2",

--- a/src/components/Location.jsx
+++ b/src/components/Location.jsx
@@ -1,4 +1,5 @@
 import { ElementList, ElementHeader } from "../components/Elements";
+import parse from "html-react-parser";
 
 export const Location = ({
   name,
@@ -12,7 +13,9 @@ export const Location = ({
     <div className="max-w-2xl px-8 py-4 mx-auto bg-green-50 rounded-lg shadow-md dark:bg-gray-800">
       <ElementHeader title={name} tag="Location" color="green" />
 
-      <p className="mt-2 text-gray-600 dark:text-gray-300">{description}</p>
+      <p className="mt-2 text-gray-600 dark:text-gray-300">
+        {parse(description)}
+      </p>
 
       {items && (
         <ElementList


### PR DESCRIPTION
Dit was de beste manier die ik vond. Alternatief is om op een DOM element de functie 'dangerouslySetInnerHTML' te gebruiken maar dat klinkt behoorlijk monkaS moet ik zeggen. Dit is vrij simpel en gaat ook gewoon goed als er geen HTML in zit maar allene strings.

Ik weet niet meer zo goed waarom we dit specifiek wilden, volgens mij wilden we dit ook om bijvoorbeeld een SVG te kunnen showen en om text te kunnen laten kleuren / plaatjes in te voeren binnen een description oid. 