### PR TITLE
Use pre-wrap for text white-space

### DIFF
--- a/src/components/Item.jsx
+++ b/src/components/Item.jsx
@@ -1,9 +1,8 @@
 import { DefaultButton } from "../components/Buttons";
-import { ElementList, ElementHeader } from "../components/Elements";
+import { ElementHeader } from "../components/Elements";
 
 export const Item = ({
   id,
-  isPresent,
   reqMet,
   name,
   description,
@@ -13,7 +12,9 @@ export const Item = ({
   <div className="max-w-2xl px-8 py-4 mx-auto bg-yellow-50 rounded-lg shadow-md dark:bg-gray-800">
     <ElementHeader title={name} tag="Item" color="yellow" />
 
-    <p className="mt-2 text-gray-600 dark:text-gray-300">{description}</p>
+    <p className="mt-2 text-gray-600 dark:text-gray-300 whitespace-pre-wrap">
+      {description}
+    </p>
 
     <DefaultButton
       children={"Pick up " + name}
@@ -32,7 +33,9 @@ export const InventoryItem = ({ name, description, events }) => (
   <div className="max-w-2xl px-8 py-4 mx-auto bg-yellow-50 rounded-lg shadow-md dark:bg-gray-800">
     <ElementHeader title={name} tag="Item" color="yellow" />
 
-    <p className="mt-2 text-gray-600 dark:text-gray-300">{description}</p>
+    <p className="mt-2 text-gray-600 dark:text-gray-300 whitespace-pre-wrap">
+      {description}
+    </p>
   </div>
 );
 

--- a/src/components/Item.stories.jsx
+++ b/src/components/Item.stories.jsx
@@ -26,3 +26,12 @@ Unavailable.args = {
   description: Faker.commerce.productDescription(),
   handleAction: () => {},
 };
+
+export const MultiLineDescription = Template.bind({});
+MultiLineDescription.args = {
+  isPresent: true,
+  reqMet: false,
+  name: Faker.commerce.productName(),
+  description: Faker.lorem.paragraphs(),
+  handleAction: () => {},
+};

--- a/src/components/Location.jsx
+++ b/src/components/Location.jsx
@@ -12,7 +12,9 @@ export const Location = ({
     <div className="max-w-2xl px-8 py-4 mx-auto bg-green-50 rounded-lg shadow-md dark:bg-gray-800">
       <ElementHeader title={name} tag="Location" color="green" />
 
-      <p className="mt-2 text-gray-600 dark:text-gray-300">{description}</p>
+      <p className="mt-2 text-gray-600 dark:text-gray-300 whitespace-pre-wrap">
+        {description}
+      </p>
 
       {items &&
         items.length > 0 && ( // This is needed to not render items when they are all picked up

--- a/src/components/Npc.jsx
+++ b/src/components/Npc.jsx
@@ -6,7 +6,9 @@ export const Npc = ({ id, reqMet, name, description, handleAction }) => {
     <div className="max-w-2xl px-8 py-4 mx-auto bg-purple-50 rounded-lg shadow-md dark:bg-gray-800">
       <ElementHeader title={name} tag="NPC" color="purple" />
 
-      <p className="mt-2 text-gray-600 dark:text-gray-300">{description}</p>
+      <p className="mt-2 text-gray-600 dark:text-gray-300 whitespace-pre-wrap">
+        {description}
+      </p>
 
       <DefaultButton
         children={"Approach " + name}

--- a/src/components/Path.jsx
+++ b/src/components/Path.jsx
@@ -13,7 +13,9 @@ export const Path = ({
     <div className="max-w-2xl px-8 py-4 mx-auto bg-pink-50 rounded-lg shadow-md dark:bg-gray-800">
       <ElementHeader title={name} tag="Path" color="pink" />
 
-      <p className="mt-2 text-gray-600 dark:text-gray-300">{description}</p>
+      <p className="mt-2 text-gray-600 dark:text-gray-300 whitespace-pre-wrap">
+        {description}
+      </p>
 
       <DefaultButton
         children={"Follow this path to " + toLocationId}


### PR DESCRIPTION
Tailwind heeft standaard alleen een paar opties voor de white-space optie, dus ik ga ervanuit dat deze vaker gebruikt worden. De pre-wrap optie lijkt het meest op wat we willen, dat er naar nieuwe regels enzo geluisterd wordt.

Heb alleen ffkes een story bij item toegevoegd omdat het een beetje overkill is het overal te doen.

`ElementList` en `isPresent` werden niet gebruikt, dus die heb ik verwijderd.

Closes #153 