### PR TITLE
Silent events implementatie

### DIFF
--- a/src/books/maze.json
+++ b/src/books/maze.json
@@ -16,6 +16,12 @@
           "events": ["dummy-path-event"]
         },
         {
+          "toLocationId": "2",
+          "name": "Test silent Event",
+          "description": "This path triggers an event that shouldn't show itself",
+          "events": ["test-silent-event"]
+        },
+        {
           "toLocationId": "test-thing-room",
           "name": "Door to thing",
           "description": "Follow this path to test the thing"
@@ -461,6 +467,9 @@
     "block-npc-test": {
       "name": "NPC unblock",
       "message": "NPC is nu zichtbaar"
+    },
+    "test-silent-event": {
+      "name": "Silent event test!"
     },
     "poke-1": {
       "name": "Poke1",

--- a/src/modules/actions.js
+++ b/src/modules/actions.js
@@ -25,7 +25,8 @@ const doEvents = (eventIds, book, gameState) => {
         revertEventIds.push(...event.revertEvents);
       }
 
-      reactions.push({ type: "EVENT_HAPPENS", message: event.message });
+      event.message &&
+        reactions.push({ type: "EVENT_HAPPENS", message: event.message });
     });
 
   // Return reactions array


### PR DESCRIPTION
Als een event geen message heeft, dan wordt het uitvoeren van het event niet meer getoond.
Background administration is nu mogelijk.

Ik twijfelde of ik de "silent event" binnen de action niet meer toe wou voegen aan de reactions, of de lijst met reactions wou filteren op reactions zonder message. Ik ben voor optie 1 gegaan. Dit leek me zelf beter zodat een ander soort actie zonder message wel gewoon getoond wordt aan de speler.

Closes #173 